### PR TITLE
Update installation_guide_no_vm.html

### DIFF
--- a/public/getting_started/installation_guide_no_vm.html
+++ b/public/getting_started/installation_guide_no_vm.html
@@ -407,39 +407,39 @@ curl
                     <p>Edit config_local.php to configure the database access:
 
 </p><pre><code class="bash">&lt;?php
-$config[ApplicationConstants::ZED_DB_USERNAME] = 'development';
-$config[ApplicationConstants::ZED_DB_PASSWORD] = 'mate20mg';
-$config[ApplicationConstants::ZED_DB_DATABASE] = 'DE_development_zed';
-$config[ApplicationConstants::ZED_DB_HOST] = '127.0.0.1';
-$config[ApplicationConstants::ZED_DB_ENGINE] = $config[ApplicationConstants::ZED_DB_ENGINE_PGSQL];
-$config[ApplicationConstants::ZED_DB_PORT] = 5432;
+$config[PropelConstants::ZED_DB_USERNAME] = 'development';
+$config[PropelConstants::ZED_DB_PASSWORD] = 'mate20mg';
+$config[PropelConstants::ZED_DB_DATABASE] = 'DE_development_zed';
+$config[PropelConstants::ZED_DB_HOST] = '127.0.0.1';
+$config[PropelConstants::ZED_DB_ENGINE] = $config[ApplicationConstants::ZED_DB_ENGINE_PGSQL];
+$config[PropelConstants::ZED_DB_PORT] = 5432;
 </code></pre>
                     <h4>Redis
 </h4>
                     <p>Configure Redis in your local configuration file:
 
 </p><pre><code class="bash">&lt;?php
-$config[ApplicationConstants::YVES_STORAGE_SESSION_REDIS_PROTOCOL] = 'tcp';
-$config[ApplicationConstants::YVES_STORAGE_SESSION_REDIS_HOST] = '127.0.0.1';
-$config[ApplicationConstants::YVES_STORAGE_SESSION_REDIS_PORT] = '10009';
-$config[ApplicationConstants::YVES_STORAGE_SESSION_REDIS_PASSWORD] = '';
+$config[SessionConstants::YVES_SESSION_REDIS_PROTOCOL] = 'tcp';
+$config[SessionConstants::YVES_SESSION_REDIS_HOST] = '127.0.0.1';
+$config[SessionConstants::YVES_SESSION_REDIS_PORT] = '10009';
+$config[SessionConstants::YVES_SESSION_REDIS_PASSWORD] = '';
 </code></pre>
                     <h4>Elasticsearch
 </h4>
                     <p>Configure Elasticsearch in your local configuration file:
 
 </p><pre><code class="bash">&lt;?php
-$config[ApplicationConstants::ELASTICA_PARAMETER__HOST] = 'localhost';
-$config[ApplicationConstants::ELASTICA_PARAMETER__TRANSPORT] = 'http';
-$config[ApplicationConstants::ELASTICA_PARAMETER__PORT] = '10005';
-$config[ApplicationConstants::ELASTICA_PARAMETER__AUTH_HEADER] = '';
-$config[ApplicationConstants::ELASTICA_PARAMETER__INDEX_NAME] = 'index_page';
-$config[ApplicationConstants::ELASTICA_PARAMETER__DOCUMENT_TYPE] = 'page';
+$config[SearchConstants::ELASTICA_PARAMETER__HOST] = 'localhost';
+$config[SearchConstants::ELASTICA_PARAMETER__TRANSPORT] = 'http';
+$config[SearchConstants::ELASTICA_PARAMETER__PORT] = '10005';
+$config[SearchConstants::ELASTICA_PARAMETER__AUTH_HEADER] = '';
+$config[SearchConstants::ELASTICA_PARAMETER__INDEX_NAME] = 'index_page';
+$config[SearchConstants::ELASTICA_PARAMETER__DOCUMENT_TYPE] = 'page';
 </code></pre>
                     <p>Configure Elasticsearch localized parameters:
 
 </p><pre><code class="bash">&lt;?php
-$config[ApplicationConstants::ELASTICA_PARAMETER__INDEX_NAME] = 'de_development_catalog';
+$config[SearchConstants::ELASTICA_PARAMETER__INDEX_NAME] = 'de_development_catalog';
 </code></pre>
                     <p>If you want to configure the hostname, set the values for Yves and Zed hostnames in your local configuration file:
 

--- a/public/getting_started/installation_guide_no_vm.html
+++ b/public/getting_started/installation_guide_no_vm.html
@@ -165,7 +165,7 @@
 
 </p>
                     <ul>
-                        <li class="bullet_list" value="1">PHP v7.1.x<br />            apt-get install php7.1-curl php7.1-gd php7.1-gmp php7.1-intl php7.1-mcrypt php7.1-pgsql php-redis php7.1-xml php7.1-mbstring php7.1-bz2</li>
+                        <li class="bullet_list" value="1">PHP v7.2.x<br />            apt-get install php7.2-curl php7.2-gd php7.2-gmp php7.2-intl php7.2-pgsql php7.2-redis php7.2-xml php7.2-mbstring php7.2-bz2 php7.2-json php7.2-bcmath php7.2-zip php7.2-cli</li>
                         <li class="bullet_list" value="2">
                 Jenkins<br />                Please install appropriate version for your system, refer to <a href="https://jenkins.io/download/">https://jenkins.io/download/</a>.<br />                Make sure it runs on port <b>localhost:10007</b>, otherwise update config.
             </li>
@@ -179,6 +179,8 @@
                         <li class="bullet_list" value="6">Redis v1.x<br />                Make sure it runs on <b>localhost:10009</b>, otherwise update config.
 </li>
                         <li class="bullet_list" value="7">PostgreSQL v9.x
+</li>
+			<li class="bullet_list" value="7">RabbitMQ 3.X<br />                Make sure it runs on <b>localhost:5672</b> and <b>localhost:15672</b>(for admin), otherwise update config.
 </li>
                     </ul>
                     <h2>Nginx Configuration

--- a/public/getting_started/installation_guide_no_vm.html
+++ b/public/getting_started/installation_guide_no_vm.html
@@ -165,7 +165,7 @@
 
 </p>
                     <ul>
-                        <li class="bullet_list" value="1">PHP v7.1.x<br />            apt-get install php7.0-curl php7.0-gd php7.0-gmp php7.0-intl php7.0-mcrypt php7.0-pgsql php-redis php7.0-xml php7.0-mbstring php7.0-bz2</li>
+                        <li class="bullet_list" value="1">PHP v7.1.x<br />            apt-get install php7.1-curl php7.1-gd php7.1-gmp php7.1-intl php7.1-mcrypt php7.1-pgsql php-redis php7.1-xml php7.1-mbstring php7.1-bz2</li>
                         <li class="bullet_list" value="2">
                 Jenkins<br />                Please install appropriate version for your system, refer to <a href="https://jenkins.io/download/">https://jenkins.io/download/</a>.<br />                Make sure it runs on port <b>localhost:10007</b>, otherwise update config.
             </li>


### PR DESCRIPTION
point packages to their 7.1 equivalent, because it's pointed out PHP 7.1 should be used